### PR TITLE
Benchmark test macro + convert

### DIFF
--- a/src/language/interpreter_new.rs
+++ b/src/language/interpreter_new.rs
@@ -1031,20 +1031,20 @@ mod tests {
     use test::Bencher;
 
     macro_rules! benchmark_test {
-        ($test_name:ident, $glenside_str: expr, $check_correct: expr, $base_env: expr) => {
+        ($test_name:ident, $glenside_str: expr, $base_env: expr, $check_correct: expr) => {
             #[bench]
             fn $test_name(b: &mut Bencher) {
                 let test = test_function!(
                     $glenside_str,
-                    $check_correct,
-                    $base_env
+                    $base_env,
+                    $check_correct
                 );
                 b.iter(|| test());
             }
         };
     }
     macro_rules! test_function {
-        ($glenside_str: expr, $check_correct: expr, $base_env: expr) => {
+        ($glenside_str: expr, $base_env: expr, $check_correct: expr) => {
             || {
                 let mut env = Environment::new();
                 for (key, value) in $base_env.into_iter() {
@@ -1056,15 +1056,7 @@ mod tests {
                 )
                 .unwrap();
 
-                match interpret(&expr, expr.as_ref().len() - 1, &env) {
-                    Value::Access(Access {
-                        tensor,
-                        access_axis,
-                    }) => {
-                        $check_correct(tensor, access_axis);
-                    }
-                    _ => panic!(),
-                }
+                $check_correct(expr, env);
             }
         }
     }
@@ -1074,17 +1066,25 @@ mod tests {
         "(compute elementwise-add
         (access (access-tensor t) 0)
         )",
-        |tensor, access_axis| {
-            assert_eq!(access_axis, 0);
-            assert_eq!(
-                tensor,
-                array![[1 + -5 + -9, -2 + 6 + 10], [3 + 0 + 11, 0 + 8 + 12]].into_dyn()
-            );
-        },
         vec![(
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(access_axis, 0);
+                    assert_eq!(
+                        tensor,
+                        array![[1 + -5 + -9, -2 + 6 + 10], [3 + 0 + 11, 0 + 8 + 12]].into_dyn()
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1092,17 +1092,25 @@ mod tests {
         "(compute elementwise-mul
         (access (access-tensor t) 0)
         )",
-        |tensor, access_axis| {
-            assert_eq!(access_axis, 0);
-            assert_eq!(
-                tensor,
-                array![[1 * -5 * -9, -2 * 6 * 10], [3 * 0 * 11, 0 * 8 * 12]].into_dyn()
-            );
-        },
         vec![(
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(access_axis, 0);
+                    assert_eq!(
+                        tensor,
+                        array![[1 * -5 * -9, -2 * 6 * 10], [3 * 0 * 11, 0 * 8 * 12]].into_dyn()
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1110,17 +1118,25 @@ mod tests {
         "(compute reduce-sum
         (access (access-tensor t) 0)
         )",
-        |tensor, access_axis| {
-            assert_eq!(access_axis, 0);
-            assert_eq!(
-                tensor,
-                ndarray::arr0(1 + -2 + 3 + 0 + -5 + 6 + 0 + 8 + -9 + 10 + 11 + 12).into_dyn()
-            );
-        },
         vec![(
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(access_axis, 0);
+                    assert_eq!(
+                        tensor,
+                        ndarray::arr0(1 + -2 + 3 + 0 + -5 + 6 + 0 + 8 + -9 + 10 + 11 + 12).into_dyn()
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1128,17 +1144,25 @@ mod tests {
         "(compute reduce-sum
         (access (access-tensor t) 1)
         )",
-        |tensor, access_axis| {
-            assert_eq!(access_axis, 1);
-            assert_eq!(
-                tensor,
-                array![1 + -2 + 3 + 0, -5 + 6 + 0 + 8, -9 + 10 + 11 + 12].into_dyn()
-            );
-        },
         vec![(
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(access_axis, 1);
+                    assert_eq!(
+                        tensor,
+                        array![1 + -2 + 3 + 0, -5 + 6 + 0 + 8, -9 + 10 + 11 + 12].into_dyn()
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1146,17 +1170,25 @@ mod tests {
         "(compute reduce-sum
         (access (access-tensor t) 2)
         )",
-        |tensor, access_axis| {
-            assert_eq!(access_axis, 2);
-            assert_eq!(
-                tensor,
-                array![[1 + -2, 3 + 0], [-5 + 6, 0 + 8], [-9 + 10, 11 + 12]].into_dyn()
-            );
-        },
         vec![(
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(access_axis, 2);
+                    assert_eq!(
+                        tensor,
+                        array![[1 + -2, 3 + 0], [-5 + 6, 0 + 8], [-9 + 10, 11 + 12]].into_dyn()
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1164,17 +1196,25 @@ mod tests {
         "(compute reduce-sum
         (access (access-tensor t) 3)
         )",
-        |tensor, access_axis| {
-            assert_eq!(access_axis, 3);
-            assert_eq!(
-                tensor,
-                array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-            );
-        },
         vec![(
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(access_axis, 3);
+                    assert_eq!(
+                        tensor,
+                        array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1182,17 +1222,25 @@ mod tests {
         "(compute relu
         (access (access-tensor t) 0)
         )",
-        |tensor, access_axis| {
-            assert_eq!(access_axis, 0);
-            assert_eq!(
-                tensor,
-                array![[[1, 0], [3, 0]], [[0, 6], [0, 8]], [[0, 10], [11, 12]],].into_dyn(),
-            );
-        },
         vec![(
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(access_axis, 0);
+                    assert_eq!(
+                        tensor,
+                        array![[[1, 0], [3, 0]], [[0, 6], [0, 8]], [[0, 10], [11, 12]],].into_dyn(),
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1200,17 +1248,25 @@ mod tests {
         "(compute relu
         (access (access-tensor t) 2)
         )",
-        |tensor, access_axis| {
-            assert_eq!(access_axis, 2);
-            assert_eq!(
-                tensor,
-                array![[[1, 0], [3, 0]], [[0, 6], [0, 8]], [[0, 10], [11, 12]],].into_dyn(),
-            );
-        },
         vec![(
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(access_axis, 2);
+                    assert_eq!(
+                        tensor,
+                        array![[[1, 0], [3, 0]], [[0, 6], [0, 8]], [[0, 10], [11, 12]],].into_dyn(),
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1218,19 +1274,27 @@ mod tests {
         "(compute dot-product
         (access (access-tensor t) 0)
         )",
-        |tensor, access_axis| {
-            assert_eq!(tensor.shape(), &[] as &[usize]);
-            assert_eq!(access_axis, 0);
-            assert_eq!(
-                tensor,
-                ndarray::arr0(1 * 5 * 9 + 2 * 6 * 10 + 3 * 7 * 11 + 4 * 8 * 12).into_dyn()
-            );
-        },
         vec![(
             "t",
             // 3 x 2 x 2
             array![[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor.shape(), &[] as &[usize]);
+                    assert_eq!(access_axis, 0);
+                    assert_eq!(
+                        tensor,
+                        ndarray::arr0(1 * 5 * 9 + 2 * 6 * 10 + 3 * 7 * 11 + 4 * 8 * 12).into_dyn()
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     benchmark_test!(
@@ -1238,19 +1302,27 @@ mod tests {
         "(compute dot-product
         (access (access-tensor t) 1)
         )",
-        |tensor, access_axis| {
-            assert_eq!(tensor.shape(), &[3]);
-            assert_eq!(access_axis, 1);
-            assert_eq!(
-                tensor,
-                array![11, 5 * 7 + 8 * 6, 9 * 11 + 10 * 12].into_dyn()
-            );
-        },
-        vec![
+        vec![(
             "t",
             // 3 x 2 x 2
             array![[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]],].into_dyn(),
-        )]
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor.shape(), &[3]);
+                    assert_eq!(access_axis, 1);
+                    assert_eq!(
+                        tensor,
+                        array![11, 5 * 7 + 8 * 6, 9 * 11 + 10 * 12].into_dyn()
+                    );
+                }
+                _ => panic!(),
+            }
+        }
     );
 
     #[test]
@@ -1285,47 +1357,43 @@ mod tests {
         }
     }
 
-    #[test]
-    fn access_cartesian_product() {
-        let mut env = Environment::new();
-        env.insert(
+    benchmark_test!(
+        access_cartesian_product,
+        "(access-cartesian-product
+        (access (access-tensor t0) 2)
+        (access (access-tensor t1) 2)
+        )",
+        vec![(
             "t0",
             // 3 x 2 x 2
             array![[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]],].into_dyn(),
-        );
-        env.insert(
+        ), (
             "t1",
             // 2 x 2 x 2
             array![[[13, 14], [15, 16]], [[17, 18], [19, 20]]].into_dyn(),
-        );
-
-        let expr = RecExpr::<Language>::from_str(
-            "(access-cartesian-product
-              (access (access-tensor t0) 2)
-              (access (access-tensor t1) 2)
-             )",
-        )
-        .unwrap();
-
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor.shape(), &[3, 2, 2, 2, 2, 2]);
-                assert_eq!(access_axis, 4);
-                assert_eq!(
-                    tensor.slice(s![0, 0, 0, 0, .., ..]),
-                    array![[1, 2], [13, 14]]
-                );
-                assert_eq!(
-                    tensor.slice(s![2, 0, 1, 0, .., ..]),
-                    array![[9, 10], [17, 18]]
-                );
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor.shape(), &[3, 2, 2, 2, 2, 2]);
+                    assert_eq!(access_axis, 4);
+                    assert_eq!(
+                        tensor.slice(s![0, 0, 0, 0, .., ..]),
+                        array![[1, 2], [13, 14]]
+                    );
+                    assert_eq!(
+                        tensor.slice(s![2, 0, 1, 0, .., ..]),
+                        array![[9, 10], [17, 18]]
+                    );
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
+
     #[test]
     fn access() {
         let mut env = Environment::new();
@@ -1354,52 +1422,48 @@ mod tests {
         interpret(&expr, expr.as_ref().len() - 1, &env);
     }
 
-    #[test]
-    fn access_windows() {
-        let mut env = Environment::new();
-        env.insert(
+    benchmark_test!(
+        access_windows,
+        "(access-windows
+            (access (access-tensor t) 3)
+            (shape 3 2 2)
+            (shape 1 1 1)
+        )",
+        vec![(
             "t",
             array![
                 [[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]],
                 [[10., 11., 12.], [13., 14., 15.], [16., 17., 18.]],
                 [[19., 20., 21.], [22., 23., 24.], [25., 26., 27.]],
             ]
-            .into_dyn(),
-        );
-
-        let expr = RecExpr::<Language>::from_str(
-            "
-             (access-windows
-              (access (access-tensor t) 3)
-              (shape 3 2 2)
-              (shape 1 1 1)
-             )",
-        )
-        .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(a) => {
-                assert_eq!(a.access_axis, 3);
-                assert_eq!(a.tensor.shape(), &[1, 2, 2, 3, 2, 2]);
-                assert_eq!(
-                    a.tensor.slice(s![0, 0, 0, .., .., ..]),
-                    array![
-                        [[1., 2.], [4., 5.]],
-                        [[10., 11.], [13., 14.]],
-                        [[19., 20.], [22., 23.]],
-                    ]
-                );
-                assert_eq!(
-                    a.tensor.slice(s![0, 1, 0, .., .., ..]),
-                    array![
-                        [[4., 5.], [7., 8.]],
-                        [[13., 14.], [16., 17.]],
-                        [[22., 23.], [25., 26.]],
-                    ]
-                );
+            .into_dyn()
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(a) => {
+                    assert_eq!(a.access_axis, 3);
+                    assert_eq!(a.tensor.shape(), &[1, 2, 2, 3, 2, 2]);
+                    assert_eq!(
+                        a.tensor.slice(s![0, 0, 0, .., .., ..]),
+                        array![
+                            [[1., 2.], [4., 5.]],
+                            [[10., 11.], [13., 14.]],
+                            [[19., 20.], [22., 23.]],
+                        ]
+                    );
+                    assert_eq!(
+                        a.tensor.slice(s![0, 1, 0, .., .., ..]),
+                        array![
+                            [[4., 5.], [7., 8.]],
+                            [[13., 14.], [16., 17.]],
+                            [[22., 23.], [25., 26.]],
+                        ]
+                    );
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
     #[test]
     fn shape() {
@@ -1614,38 +1678,38 @@ mod tests {
         };
     }
 
-    #[test]
-    fn access_pad() {
-        let mut env = Environment::new();
-        env.insert("t", array![[1., 2.], [3., 4.]].into_dyn());
-
-        let expr =
-            RecExpr::<Language>::from_str("(access-pad (access-tensor t) zero-padding 0 2 4)")
-                .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(
+    benchmark_test!(
+        access_pad,
+        "(access-pad (access-tensor t) zero-padding 0 2 4)",
+        vec![(
+            "t", array![[1., 2.], [3., 4.]].into_dyn()
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
                     tensor,
-                    array![
-                        [0., 0.],
-                        [0., 0.],
-                        [1., 2.],
-                        [3., 4.],
-                        [0., 0.],
-                        [0., 0.],
-                        [0., 0.],
-                        [0., 0.]
-                    ]
-                    .into_dyn()
-                );
-                assert_eq!(access_axis, 0);
+                    access_axis,
+                }) => {
+                    assert_eq!(
+                        tensor,
+                        array![
+                            [0., 0.],
+                            [0., 0.],
+                            [1., 2.],
+                            [3., 4.],
+                            [0., 0.],
+                            [0., 0.],
+                            [0., 0.],
+                            [0., 0.]
+                        ]
+                        .into_dyn()
+                    );
+                    assert_eq!(access_axis, 0);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
     #[test]
     fn compute_reduce_max_0() {
@@ -1850,83 +1914,81 @@ mod tests {
         }
     }
 
-    #[test]
-    fn access_pair_0() {
-        let mut env = Environment::new();
-        env.insert("a", array![[1, 2], [3, 4]].into_dyn());
-        env.insert("b", array![[5, 6], [7, 8]].into_dyn());
-
-        let expr = RecExpr::<Language>::from_str(
-            "(access-pair (access (access-tensor a) 0) (access (access-tensor b) 0))",
-        )
-        .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor.shape(), [2, 2, 2]);
-                assert_eq!(
+    benchmark_test!(
+        access_pair_0,
+        "(access-pair (access (access-tensor a) 0) (access (access-tensor b) 0))",
+        vec![(
+            "a", array![[1, 2], [3, 4]].into_dyn()
+        ), (
+            "b", array![[5, 6], [7, 8]].into_dyn()
+        )],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
                     tensor,
-                    array![[[1, 2], [3, 4]], [[5, 6], [7, 8]]].into_dyn()
-                );
-                assert_eq!(access_axis, 0);
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor.shape(), [2, 2, 2]);
+                    assert_eq!(
+                        tensor,
+                        array![[[1, 2], [3, 4]], [[5, 6], [7, 8]]].into_dyn()
+                    );
+                    assert_eq!(access_axis, 0);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
-    #[test]
-    fn access_pair_1() {
-        let mut env = Environment::new();
-        env.insert("a", array![[1, 2], [3, 4]].into_dyn());
-        env.insert("b", array![[5, 6], [7, 8]].into_dyn());
-
-        let expr = RecExpr::<Language>::from_str(
-            "(access-pair (access (access-tensor a) 1) (access (access-tensor b) 1))",
-        )
-        .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor.shape(), [2, 2, 2]);
-                assert_eq!(
+    benchmark_test!(
+        access_pair_1,
+        "(access-pair (access (access-tensor a) 1) (access (access-tensor b) 1))",
+        vec![
+            ("a", array![[1, 2], [3, 4]].into_dyn()),
+            ("b", array![[5, 6], [7, 8]].into_dyn())
+        ],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
                     tensor,
-                    array![[[1, 2], [5, 6]], [[3, 4], [7, 8]]].into_dyn()
-                );
-                assert_eq!(access_axis, 1);
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor.shape(), [2, 2, 2]);
+                    assert_eq!(
+                        tensor,
+                        array![[[1, 2], [5, 6]], [[3, 4], [7, 8]]].into_dyn()
+                    );
+                    assert_eq!(access_axis, 1);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
-    #[test]
-    fn access_pair_2() {
-        let mut env = Environment::new();
-        env.insert("a", array![[1, 2], [3, 4]].into_dyn());
-        env.insert("b", array![[5, 6], [7, 8]].into_dyn());
-
-        let expr = RecExpr::<Language>::from_str(
-            "(access-pair (access (access-tensor a) 2) (access (access-tensor b) 2))",
-        )
-        .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor.shape(), [2, 2, 2]);
-                assert_eq!(
+    benchmark_test!(
+        access_pair_2,
+        "(access-pair (access (access-tensor a) 2) (access (access-tensor b) 2))",
+        vec![
+            ("a", array![[1, 2], [3, 4]].into_dyn()),
+            ("b", array![[5, 6], [7, 8]].into_dyn())
+        ],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
                     tensor,
-                    array![[[1, 5], [2, 6]], [[3, 7], [4, 8]]].into_dyn()
-                );
-                assert_eq!(access_axis, 2);
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor.shape(), [2, 2, 2]);
+                    assert_eq!(
+                        tensor,
+                        array![[[1, 5], [2, 6]], [[3, 7], [4, 8]]].into_dyn()
+                    );
+                    assert_eq!(access_axis, 2);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
     #[test]
     #[should_panic]
@@ -2585,49 +2647,47 @@ mod tests {
         }
     }
 
-    #[test]
-    fn access_concatenate_0() {
-        let mut env = Environment::new();
-        env.insert("t", array![[1, 2]].into_dyn());
-        env.insert("n", array![[1, 2], [3, 4]].into_dyn());
-
-        let expr = RecExpr::<Language>::from_str(
-            "(access-concatenate (access (access-tensor t) 0) (access (access-tensor n) 0) 0)",
-        )
-        .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor, array![[1, 2], [1, 2], [3, 4]].into_dyn());
-                assert_eq!(access_axis, 0);
+    benchmark_test!(
+        access_concatenate_0,
+        "(access-concatenate (access (access-tensor t) 0) (access (access-tensor n) 0) 0)",
+        vec![
+            ("t", array![[1, 2]].into_dyn()),
+            ("n", array![[1, 2], [3, 4]].into_dyn())
+        ],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor, array![[1, 2], [1, 2], [3, 4]].into_dyn());
+                    assert_eq!(access_axis, 0);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
-    #[test]
-    fn access_concatenate_1() {
-        let mut env = Environment::new();
-        env.insert("t", array![[1], [2]].into_dyn());
-        env.insert("n", array![[1, 2], [3, 4]].into_dyn());
-
-        let expr = RecExpr::<Language>::from_str(
-            "(access-concatenate (access (access-tensor t) 0) (access (access-tensor n) 0) 1)",
-        )
-        .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor, array![[1, 1, 2], [2, 3, 4]].into_dyn());
-                assert_eq!(access_axis, 0);
+    benchmark_test!(
+        access_concatenate_1,
+        "(access-concatenate (access (access-tensor t) 0) (access (access-tensor n) 0) 1)",
+        vec![
+            ("t", array![[1], [2]].into_dyn()),
+            ("n", array![[1, 2], [3, 4]].into_dyn())
+        ],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor, array![[1, 1, 2], [2, 3, 4]].into_dyn());
+                    assert_eq!(access_axis, 0);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
     #[test]
     #[should_panic]
@@ -2657,65 +2717,65 @@ mod tests {
         interpret(&expr, expr.as_ref().len() - 1, &env);
     }
 
-    #[test]
-    fn access_slice_0() {
-        let mut env = Environment::new();
-        env.insert("t", array![[1, 2], [3, 4]].into_dyn());
-
-        let expr =
-            RecExpr::<Language>::from_str("(access-slice (access (access-tensor t) 0) 0 0 1)")
-                .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor, array![[1, 2]].into_dyn());
-                assert_eq!(access_axis, 0);
+    benchmark_test!(
+        access_slice_0,
+        "(access-slice (access (access-tensor t) 0) 0 0 1)",
+        vec![
+            ("t", array![[1, 2], [3, 4]].into_dyn())
+        ],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor, array![[1, 2]].into_dyn());
+                    assert_eq!(access_axis, 0);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
-    #[test]
-    fn access_slice_1() {
-        let mut env = Environment::new();
-        env.insert("t", array![[1, 2], [3, 4]].into_dyn());
-
-        let expr =
-            RecExpr::<Language>::from_str("(access-slice (access (access-tensor t) 0) 0 0 2)")
-                .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor, array![[1, 2], [3, 4]].into_dyn());
-                assert_eq!(access_axis, 0);
+    benchmark_test!(
+        access_slice_1,
+        "(access-slice (access (access-tensor t) 0) 0 0 2)",
+        vec![
+            ("t", array![[1, 2], [3, 4]].into_dyn())
+        ],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor, array![[1, 2], [3, 4]].into_dyn());
+                    assert_eq!(access_axis, 0);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
-
-    #[test]
-    fn access_slice_2() {
-        let mut env = Environment::new();
-        env.insert("t", array![[1, 2], [3, 4]].into_dyn());
-
-        let expr =
-            RecExpr::<Language>::from_str("(access-slice (access (access-tensor t) 0) 1 1 2)")
-                .unwrap();
-        match interpret(&expr, expr.as_ref().len() - 1, &env) {
-            Value::Access(Access {
-                tensor,
-                access_axis,
-            }) => {
-                assert_eq!(tensor, array![[2], [4]].into_dyn());
-                assert_eq!(access_axis, 0);
+    );
+    
+    benchmark_test!(
+        access_slice_2,
+        "(access-slice (access (access-tensor t) 0) 1 1 2)",
+        vec![
+            ("t", array![[1, 2], [3, 4]].into_dyn())
+        ],
+        |expr, env| {
+            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+                Value::Access(Access {
+                    tensor,
+                    access_axis,
+                }) => {
+                    assert_eq!(tensor, array![[2], [4]].into_dyn());
+                    assert_eq!(access_axis, 0);
+                }
+                _ => panic!(),
             }
-            _ => panic!(),
         }
-    }
+    );
 
     #[test]
     #[should_panic]

--- a/src/language/interpreter_new.rs
+++ b/src/language/interpreter_new.rs
@@ -1030,7 +1030,7 @@ mod tests {
     use std::str::FromStr;
     use test::Bencher;
 
-    /// Creates an benchmark test for the interpreter
+    /// Creates a benchmark test for the interpreter
     /// The test does the following:
     ///  1. Parses $glenside_str as glenside expression
     ///  2. Creates a new Environment from the vector of (key, value) pairs
@@ -1044,14 +1044,6 @@ mod tests {
         ($test_name:ident, $glenside_str: expr, $env: expr, $check_correct: expr) => {
             #[bench]
             fn $test_name(b: &mut Bencher) {
-                let test = test_function!($glenside_str, $env, $check_correct);
-                b.iter(|| test());
-            }
-        };
-    }
-    macro_rules! test_function {
-        ($glenside_str: expr, $env: expr, $check_correct: expr) => {
-            || {
                 let mut env = Environment::new();
                 for (key, value) in $env.into_iter() {
                     env.insert(key, value);
@@ -1059,8 +1051,14 @@ mod tests {
 
                 let expr = RecExpr::<Language>::from_str($glenside_str).unwrap();
 
-                let value = interpret(&expr, expr.as_ref().len() - 1, &env);
-                $check_correct(value);
+                b.iter(|| {
+                    // use black box to prevent compiler optimizations
+                    let expr = test::black_box(&expr);
+                    let env = test::black_box(&env);
+
+                    let value = interpret(&expr, expr.as_ref().len() - 1, &env);
+                    $check_correct(value);
+                });
             }
         };
     }

--- a/src/language/interpreter_new.rs
+++ b/src/language/interpreter_new.rs
@@ -1044,11 +1044,7 @@ mod tests {
         ($test_name:ident, $glenside_str: expr, $base_env: expr, $check_correct: expr) => {
             #[bench]
             fn $test_name(b: &mut Bencher) {
-                let test = test_function!(
-                    $glenside_str,
-                    $base_env,
-                    $check_correct
-                );
+                let test = test_function!($glenside_str, $base_env, $check_correct);
                 b.iter(|| test());
             }
         };
@@ -1059,16 +1055,13 @@ mod tests {
                 let mut env = Environment::new();
                 for (key, value) in $base_env.into_iter() {
                     env.insert(key, value);
-                }               
+                }
 
-                let expr = RecExpr::<Language>::from_str(
-                    $glenside_str,
-                )
-                .unwrap();
+                let expr = RecExpr::<Language>::from_str($glenside_str).unwrap();
 
                 $check_correct(expr, env);
             }
-        }
+        };
     }
 
     benchmark_test!(
@@ -1141,7 +1134,8 @@ mod tests {
                     assert_eq!(access_axis, 0);
                     assert_eq!(
                         tensor,
-                        ndarray::arr0(1 + -2 + 3 + 0 + -5 + 6 + 0 + 8 + -9 + 10 + 11 + 12).into_dyn()
+                        ndarray::arr0(1 + -2 + 3 + 0 + -5 + 6 + 0 + 8 + -9 + 10 + 11 + 12)
+                            .into_dyn()
                     );
                 }
                 _ => panic!(),
@@ -1219,7 +1213,8 @@ mod tests {
                     assert_eq!(access_axis, 3);
                     assert_eq!(
                         tensor,
-                        array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
+                        array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],]
+                            .into_dyn(),
                     );
                 }
                 _ => panic!(),
@@ -1373,15 +1368,18 @@ mod tests {
         (access (access-tensor t0) 2)
         (access (access-tensor t1) 2)
         )",
-        vec![(
-            "t0",
-            // 3 x 2 x 2
-            array![[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]],].into_dyn(),
-        ), (
-            "t1",
-            // 2 x 2 x 2
-            array![[[13, 14], [15, 16]], [[17, 18], [19, 20]]].into_dyn(),
-        )],
+        vec![
+            (
+                "t0",
+                // 3 x 2 x 2
+                array![[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]],].into_dyn(),
+            ),
+            (
+                "t1",
+                // 2 x 2 x 2
+                array![[[13, 14], [15, 16]], [[17, 18], [19, 20]]].into_dyn(),
+            )
+        ],
         |expr, env| {
             match interpret(&expr, expr.as_ref().len() - 1, &env) {
                 Value::Access(Access {
@@ -1691,9 +1689,7 @@ mod tests {
     benchmark_test!(
         access_pad,
         "(access-pad (access-tensor t) zero-padding 0 2 4)",
-        vec![(
-            "t", array![[1., 2.], [3., 4.]].into_dyn()
-        )],
+        vec![("t", array![[1., 2.], [3., 4.]].into_dyn())],
         |expr, env| {
             match interpret(&expr, expr.as_ref().len() - 1, &env) {
                 Value::Access(Access {
@@ -1927,11 +1923,10 @@ mod tests {
     benchmark_test!(
         access_pair_0,
         "(access-pair (access (access-tensor a) 0) (access (access-tensor b) 0))",
-        vec![(
-            "a", array![[1, 2], [3, 4]].into_dyn()
-        ), (
-            "b", array![[5, 6], [7, 8]].into_dyn()
-        )],
+        vec![
+            ("a", array![[1, 2], [3, 4]].into_dyn()),
+            ("b", array![[5, 6], [7, 8]].into_dyn())
+        ],
         |expr, env| {
             match interpret(&expr, expr.as_ref().len() - 1, &env) {
                 Value::Access(Access {
@@ -2730,9 +2725,7 @@ mod tests {
     benchmark_test!(
         access_slice_0,
         "(access-slice (access (access-tensor t) 0) 0 0 1)",
-        vec![
-            ("t", array![[1, 2], [3, 4]].into_dyn())
-        ],
+        vec![("t", array![[1, 2], [3, 4]].into_dyn())],
         |expr, env| {
             match interpret(&expr, expr.as_ref().len() - 1, &env) {
                 Value::Access(Access {
@@ -2750,9 +2743,7 @@ mod tests {
     benchmark_test!(
         access_slice_1,
         "(access-slice (access (access-tensor t) 0) 0 0 2)",
-        vec![
-            ("t", array![[1, 2], [3, 4]].into_dyn())
-        ],
+        vec![("t", array![[1, 2], [3, 4]].into_dyn())],
         |expr, env| {
             match interpret(&expr, expr.as_ref().len() - 1, &env) {
                 Value::Access(Access {
@@ -2766,13 +2757,11 @@ mod tests {
             }
         }
     );
-    
+
     benchmark_test!(
         access_slice_2,
         "(access-slice (access (access-tensor t) 0) 1 1 2)",
-        vec![
-            ("t", array![[1, 2], [3, 4]].into_dyn())
-        ],
+        vec![("t", array![[1, 2], [3, 4]].into_dyn())],
         |expr, env| {
             match interpret(&expr, expr.as_ref().len() - 1, &env) {
                 Value::Access(Access {

--- a/src/language/interpreter_new.rs
+++ b/src/language/interpreter_new.rs
@@ -1032,7 +1032,7 @@ mod tests {
 
     /// Creates an benchmark test for interpreter
     /// The test does the following:
-    ///  1. Converts $glenside_str to glenside by parsing
+    ///  1. Parses $glenside_str as glenside expression
     ///  2. Creates a new Environment from the vector of (key, value) pairs in base_env
     ///  3. Calls check_correct with the glenside expression + environment
     /// $test_name: the name of the created benchmark test

--- a/src/language/interpreter_new.rs
+++ b/src/language/interpreter_new.rs
@@ -1030,36 +1030,37 @@ mod tests {
     use std::str::FromStr;
     use test::Bencher;
 
-    /// Creates an benchmark test for interpreter
+    /// Creates an benchmark test for the interpreter
     /// The test does the following:
     ///  1. Parses $glenside_str as glenside expression
-    ///  2. Creates a new Environment from the vector of (key, value) pairs in base_env
-    ///  3. Calls check_correct with the glenside expression + environment
+    ///  2. Creates a new Environment from the vector of (key, value) pairs
+    ///  3. Calls the interpreter with the glenside expression and env,
+    ///         and passes the value to check_correct
     /// $test_name: the name of the created benchmark test
     /// $glenside_str: A string containing the Glenside program
-    /// $base_env: A vector or 2-tuples of key, value pairs to put into the environment
-    /// $check_correct: A closure with arguments (glenside_expr, env) that should call the interpreter
-    ///     and checks for correctness
+    /// $env: A vector of 2-tuples of key, value pairs to put into the environment
+    /// $check_correct: A closure with arguments (value) that checks for correctness
     macro_rules! benchmark_test {
-        ($test_name:ident, $glenside_str: expr, $base_env: expr, $check_correct: expr) => {
+        ($test_name:ident, $glenside_str: expr, $env: expr, $check_correct: expr) => {
             #[bench]
             fn $test_name(b: &mut Bencher) {
-                let test = test_function!($glenside_str, $base_env, $check_correct);
+                let test = test_function!($glenside_str, $env, $check_correct);
                 b.iter(|| test());
             }
         };
     }
     macro_rules! test_function {
-        ($glenside_str: expr, $base_env: expr, $check_correct: expr) => {
+        ($glenside_str: expr, $env: expr, $check_correct: expr) => {
             || {
                 let mut env = Environment::new();
-                for (key, value) in $base_env.into_iter() {
+                for (key, value) in $env.into_iter() {
                     env.insert(key, value);
                 }
 
                 let expr = RecExpr::<Language>::from_str($glenside_str).unwrap();
 
-                $check_correct(expr, env);
+                let value = interpret(&expr, expr.as_ref().len() - 1, &env);
+                $check_correct(value);
             }
         };
     }
@@ -1073,8 +1074,8 @@ mod tests {
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1099,8 +1100,8 @@ mod tests {
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1125,8 +1126,8 @@ mod tests {
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1152,8 +1153,8 @@ mod tests {
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1178,8 +1179,8 @@ mod tests {
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1204,8 +1205,8 @@ mod tests {
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1231,8 +1232,8 @@ mod tests {
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1257,8 +1258,8 @@ mod tests {
             "t",
             array![[[1, -2], [3, 0]], [[-5, 6], [0, 8]], [[-9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1284,8 +1285,8 @@ mod tests {
             // 3 x 2 x 2
             array![[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1312,8 +1313,8 @@ mod tests {
             // 3 x 2 x 2
             array![[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]],].into_dyn(),
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1380,8 +1381,8 @@ mod tests {
                 array![[[13, 14], [15, 16]], [[17, 18], [19, 20]]].into_dyn(),
             )
         ],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1446,8 +1447,8 @@ mod tests {
             ]
             .into_dyn()
         )],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(a) => {
                     assert_eq!(a.access_axis, 3);
                     assert_eq!(a.tensor.shape(), &[1, 2, 2, 3, 2, 2]);
@@ -1690,8 +1691,8 @@ mod tests {
         access_pad,
         "(access-pad (access-tensor t) zero-padding 0 2 4)",
         vec![("t", array![[1., 2.], [3., 4.]].into_dyn())],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1927,8 +1928,8 @@ mod tests {
             ("a", array![[1, 2], [3, 4]].into_dyn()),
             ("b", array![[5, 6], [7, 8]].into_dyn())
         ],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1952,8 +1953,8 @@ mod tests {
             ("a", array![[1, 2], [3, 4]].into_dyn()),
             ("b", array![[5, 6], [7, 8]].into_dyn())
         ],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -1977,8 +1978,8 @@ mod tests {
             ("a", array![[1, 2], [3, 4]].into_dyn()),
             ("b", array![[5, 6], [7, 8]].into_dyn())
         ],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -2659,8 +2660,8 @@ mod tests {
             ("t", array![[1, 2]].into_dyn()),
             ("n", array![[1, 2], [3, 4]].into_dyn())
         ],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -2680,8 +2681,8 @@ mod tests {
             ("t", array![[1], [2]].into_dyn()),
             ("n", array![[1, 2], [3, 4]].into_dyn())
         ],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -2726,8 +2727,8 @@ mod tests {
         access_slice_0,
         "(access-slice (access (access-tensor t) 0) 0 0 1)",
         vec![("t", array![[1, 2], [3, 4]].into_dyn())],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -2744,8 +2745,8 @@ mod tests {
         access_slice_1,
         "(access-slice (access (access-tensor t) 0) 0 0 2)",
         vec![("t", array![[1, 2], [3, 4]].into_dyn())],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,
@@ -2762,8 +2763,8 @@ mod tests {
         access_slice_2,
         "(access-slice (access (access-tensor t) 0) 1 1 2)",
         vec![("t", array![[1, 2], [3, 4]].into_dyn())],
-        |expr, env| {
-            match interpret(&expr, expr.as_ref().len() - 1, &env) {
+        |value| {
+            match value {
                 Value::Access(Access {
                     tensor,
                     access_axis,

--- a/src/language/interpreter_new.rs
+++ b/src/language/interpreter_new.rs
@@ -1030,6 +1030,16 @@ mod tests {
     use std::str::FromStr;
     use test::Bencher;
 
+    /// Creates an benchmark test for interpreter
+    /// The test does the following:
+    ///  1. Converts $glenside_str to glenside by parsing
+    ///  2. Creates a new Environment from the vector of (key, value) pairs in base_env
+    ///  3. Calls check_correct with the glenside expression + environment
+    /// $test_name: the name of the created benchmark test
+    /// $glenside_str: A string containing the Glenside program
+    /// $base_env: A vector or 2-tuples of key, value pairs to put into the environment
+    /// $check_correct: A closure with arguments (glenside_expr, env) that should call the interpreter
+    ///     and checks for correctness
     macro_rules! benchmark_test {
         ($test_name:ident, $glenside_str: expr, $base_env: expr, $check_correct: expr) => {
             #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(test)]
+
 pub mod codegen;
 pub mod extraction;
 pub mod hw_design_language;


### PR DESCRIPTION
#33 and #26 

add benchmark test macro for interpreter + converts the important tests to use the macro

cc: @gussmith23 
