### PR TITLE
Simplifying rewrites for flatten/reshape

### DIFF
--- a/tests/tensorize-conv2d-with-padding-and-splitting.rs
+++ b/tests/tensorize-conv2d-with-padding-and-splitting.rs
@@ -48,7 +48,12 @@ fn conv2d_im2col_tensorize_to_smaller_array_with_padding_and_slicing() {
     let id = egraph.add_expr(&expr);
 
     let rws = vec![
+        // Flatten/unflatten all accesses to discover im2col, plus simplifying
+        // rewrites to simplify the mess that this rewrite creates.
         glenside::language::rewrites::flatten_unflatten_any_access(),
+        glenside::language::rewrites::simplify_access_flattens(),
+        glenside::language::rewrites::simplify_access_reshapes(),
+
         glenside::language::rewrites::bubble_reshape_through_cartesian_product(),
         glenside::language::rewrites::bubble_reshape_through_compute_dot_product(),
         glenside::language::rewrites::bubble_access_concatenate_through_access_cartesian_product_not_item_axis_left(),


### PR DESCRIPTION
The intention here was to add simplifying rewrites so that flatten/unflatten wouldn't run rampant. If we could add more equivalences (i.e. saying that stacking flattens is equivalent to just one flatten, or that flatten-then-reshape is equal to just reshape) then we can compress the egraph down. However, we haven't seemed to improve much:

Without rewrites:
```
Runner report
=============
  Stop reason: TimeLimit(60.958206912)
  Iterations: 41
  Egraph size: 278240 nodes, 262325 classes, 278269 memo
  Rebuilds: 10977, 267.73 per iter
  Total time: 60.27503701900001
    Search:  (0.09) 5.527444559
    Apply:   (0.15) 8.843468115999999
    Rebuild: (0.76) 45.904067723999994
```

With rewrites:
```
Runner report
=============
  Stop reason: TimeLimit(61.440639892)
  Iterations: 40
  Egraph size: 280628 nodes, 260861 classes, 280782 memo
  Rebuilds: 14521, 363.02 per iter
  Total time: 60.788746081999996
    Search:  (0.09) 5.595972895000001
    Apply:   (0.14) 8.638404146000001
```

It seems like the number of classes goes down somewhat, but overall performance degrades (we run fewer iterations, have more rebuilding). I'm not quite sure how to interpret this -- is it just that these rewrites aren't actually useful, and are just hurting us?