### PR TITLE
Enable more linear layer matching on FlexASR

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -698,6 +698,7 @@ fn codegen_helper(
             };
 
             match relay_op {
+                RelayOperator::RelayZeros => todo!(),
                 RelayOperator::RelayBatchMatmul => todo!(),
                 RelayOperator::RelayLayerNorm => todo!(),
                 RelayOperator::RelayRound => todo!(),

--- a/src/language/language.rs
+++ b/src/language/language.rs
@@ -445,6 +445,8 @@ pub enum RelayOperator {
     RelayLayerNorm,
 
     RelayBatchMatmul,
+
+    RelayZeros,
 }
 impl FromStr for RelayOperator {
     type Err = ();
@@ -484,6 +486,7 @@ impl FromStr for RelayOperator {
             "relay-strided-slice" => Ok(RelayOperator::RelayStridedSlice),
             "relay-layer-norm" => Ok(RelayOperator::RelayLayerNorm),
             "relay-batch-matmul" => Ok(RelayOperator::RelayBatchMatmul),
+            "relay-zeros" => Ok(RelayOperator::RelayZeros),
             _ => Err(()),
         }
     }
@@ -529,6 +532,7 @@ impl Display for RelayOperator {
                 RelayOperator::RelayLogSoftmax => "relay-log-softmax",
                 RelayOperator::RelayLayerNorm => "relay-layer-norm",
                 RelayOperator::RelayBatchMatmul => "relay-batch-matmul",
+                RelayOperator::RelayZeros => "relay-zeros",
             }
         )
     }
@@ -1916,6 +1920,24 @@ impl egg::Analysis<Language> for MyAnalysis {
                 };
 
                 match op_type {
+                    crate::language::RelayOperator::RelayZeros => {
+                        let s = match params[1..]
+                            .iter()
+                            .map(|id| &egraph[*id].data)
+                            .collect::<Vec<_>>()[..]
+                        {
+                            [MyAnalysisData::Shape(s)] => s.shape.clone(),
+
+                            _ => panic!(),
+                        };
+                        MyAnalysisData::AccessPattern(AccessPatternData {
+                            shape: s.clone(),
+                            item_shape: IxDyn(&[]),
+                            zero_regions: HashMap::default(),
+                            relay_shape: Some(s),
+                            contains_accelerator_calls: false,
+                        })
+                    }
                     crate::language::RelayOperator::RelayBatchMatmul => {
                         let (a0, a1) = match params[1..]
                             .iter()

--- a/src/language/language.rs
+++ b/src/language/language.rs
@@ -3465,7 +3465,7 @@ impl egg::Analysis<Language> for MyAnalysis {
                         } else {
                             a.clone()
                         }
-                    },
+                    }
                     _ => panic!(),
                 };
                 // TODO(@gussmith23) Implement zero_regions

--- a/src/language/rewrites.rs
+++ b/src/language/rewrites.rs
@@ -1170,7 +1170,11 @@ pub fn linear_layer_accelerator_rewrites() -> RW {
 pub fn glenside_matmul_to_relay_dense() -> RW {
     rewrite!("glenside_matmul_to_relay_dense";
              "(compute dot-product (access-cartesian-product ?x ?w))"
-             => "(relay-operator-call relay-dense ?x ?w)")
+             => "(relay-operator-call relay-dense ?x ?w)"
+            if constrain_access("?w".parse().unwrap(),
+                                |v| v.as_vec().len() == 2)
+            if constrain_access("?x".parse().unwrap(),
+                                |v| v.as_vec().len() == 2))
 }
 
 /// Experimental rewrite to add a bias add on any dense.

--- a/src/language/rewrites.rs
+++ b/src/language/rewrites.rs
@@ -1207,7 +1207,7 @@ pub fn add_bias_add_to_dense() -> RW {
             .apply_one(egraph, eclass, subst)
         }
     }
-    rewrite!("glenside_matmul_to_relay_dense";
+    rewrite!("add_bias_add_to_dense";
              "(relay-operator-call relay-dense ?x ?w)"
              => { ApplierImpl })
 }

--- a/src/language/rewrites.rs
+++ b/src/language/rewrites.rs
@@ -1196,7 +1196,7 @@ pub fn add_bias_add_to_dense() -> RW {
             };
 
             format!(
-                "(relay-operator-call bias-add 
+                "(relay-operator-call relay-bias-add 
                   (relay-operator-call relay-dense ?x ?w)
                   (relay-operator-call relay-zeros (shape {}))
                   1)",


### PR DESCRIPTION
We do this by rewriting matmuls to matmuls plus bias adds (with 0 biases).